### PR TITLE
ci: pull request template and fix to code coverage badge

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,38 @@
+# readmerunner PR
+
+## Description
+
+_Provide a detailed explanation of the changes you have made. Include the reasons
+behind these changes and any relevant context. Link any related issues._
+
+## Type of Change
+
+- [ ] Feature (feat)
+- [ ] Fix (fix)
+- [ ] Documentation (docs)
+- [ ] Refactoring (refactor)
+- [ ] Reverting change (revert)
+- [ ] Performance improvement (perf)
+- [ ] Chore (chore)
+- [ ] Test (test)
+- [ ] Continuous Integration (ci)
+
+## Testing
+
+_Detail the testing you have performed to ensure that these changes function as
+intended. Include information about any added tests._
+
+## Additional Information
+
+_Any additional information that reviewers should be aware of._
+
+## Checklist
+
+- [ ] My code adheres to the coding and [style guidelines][1] of the project.
+- [ ] My PR title follows the [conventional commit][2] format.
+- [ ] I have made corresponding changes to the documentation, e.g., comments, READMEs
+- [ ] My changes generate no new errors/warnings
+
+<!-- links -->
+[1]: ../CONTRIBUTING.md
+[2]: ../CONTRIBUTING.md#pr-title

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -37,7 +37,7 @@ jobs:
       - name: Run Test
         run: |
           go test -v ./... -covermode=count -coverprofile=coverage.out
-          go tool cover -o=coverage.out
+          go tool cover -func=coverage.out -o=coverage.out
       - name: Go Coverage Badge  # Pass the `coverage.out` output to this action
         uses: tj-actions/coverage-badge-go@84540b9f82b4f569ac9f248cf6f2893ac3cc4791 # v2
         with:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Readme Runner
+[![Coverage](https://img.shields.io/badge/Coverage-61.2%25-yellow)](https://github.com/seanblong/readmerunner/actions/workflows/test.yaml)
 
 [![CI](https://github.com/seanblong/embedmd/actions/workflows/test.yaml/badge.svg)](https://github.com/seanblong/readmerunner/actions/workflows/test.yaml)
 [![Go Report Card](https://goreportcard.com/badge/github.com/seanblong/readmerunner)](https://goreportcard.com/report/github.com/seanblong/readmerunner)


### PR DESCRIPTION
# readmerunner PR

## Description

Here's a look at the new PR template.  I've also added a missing parameter to one of the GHA tasks.

## Type of Change

- [ ] Feature (feat)
- [ ] Fix (fix)
- [ ] Documentation (docs)
- [ ] Refactoring (refactor)
- [ ] Reverting change (revert)
- [ ] Performance improvement (perf)
- [ ] Chore (chore)
- [ ] Test (test)
- [X] Continuous Integration (ci)

## Testing

I've run the code coverage piece locally and that should now match what is provided in the sample from 'tj-actions'

## Additional Information

N/A

## Checklist

- [X] My code adheres to the coding and [style guidelines][1] of the project.
- [X] My PR title follows the [conventional commit][2] format.
- [X] I have made corresponding changes to the documentation, e.g., comments, READMEs
- [X] My changes generate no new errors/warnings

<!-- links -->
[1]: ../CONTRIBUTING.md
[2]: ../CONTRIBUTING.md#pr-title
