### PR TITLE
refactor: split parsing logic from code runner logic.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Readme Runner
 
-[![Coverage](https://img.shields.io/badge/Coverage-72.1%25-brightgreen)](https://github.com/seanblong/readmerunner/actions/workflows/test.yaml)
+[![Coverage](https://img.shields.io/badge/Coverage-74.2%25-brightgreen)](https://github.com/seanblong/readmerunner/actions/workflows/test.yaml)
 [![CI](https://github.com/seanblong/embedmd/actions/workflows/test.yaml/badge.svg)](https://github.com/seanblong/readmerunner/actions/workflows/test.yaml)
 [![Go Report Card](https://goreportcard.com/badge/github.com/seanblong/readmerunner)](https://goreportcard.com/report/github.com/seanblong/readmerunner)
 [![pre-commit.ci status](https://results.pre-commit.ci/badge/github/seanblong/readmerunner/main.svg)](https://results.pre-commit.ci/latest/github/seanblong/readmerunner/main)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Readme Runner
 
-[![Coverage](https://img.shields.io/badge/Coverage-73.6%25-brightgreen)](https://github.com/seanblong/readmerunner/actions/workflows/test.yaml)
+[![Coverage](https://img.shields.io/badge/Coverage-72.1%25-brightgreen)](https://github.com/seanblong/readmerunner/actions/workflows/test.yaml)
 [![CI](https://github.com/seanblong/embedmd/actions/workflows/test.yaml/badge.svg)](https://github.com/seanblong/readmerunner/actions/workflows/test.yaml)
 [![Go Report Card](https://goreportcard.com/badge/github.com/seanblong/readmerunner)](https://goreportcard.com/report/github.com/seanblong/readmerunner)
 [![pre-commit.ci status](https://results.pre-commit.ci/badge/github/seanblong/readmerunner/main.svg)](https://results.pre-commit.ci/latest/github/seanblong/readmerunner/main)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Readme Runner
 
-[![Coverage](https://img.shields.io/badge/Coverage-75.7%25-brightgreen)](https://github.com/seanblong/readmerunner/actions/workflows/test.yaml)
+[![Coverage](https://img.shields.io/badge/Coverage-73.1%25-brightgreen)](https://github.com/seanblong/readmerunner/actions/workflows/test.yaml)
 [![CI](https://github.com/seanblong/embedmd/actions/workflows/test.yaml/badge.svg)](https://github.com/seanblong/readmerunner/actions/workflows/test.yaml)
 [![Go Report Card](https://goreportcard.com/badge/github.com/seanblong/readmerunner)](https://goreportcard.com/report/github.com/seanblong/readmerunner)
 [![pre-commit.ci status](https://results.pre-commit.ci/badge/github/seanblong/readmerunner/main.svg)](https://results.pre-commit.ci/latest/github/seanblong/readmerunner/main)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Readme Runner
 
-[![Coverage](https://img.shields.io/badge/Coverage-73.1%25-brightgreen)](https://github.com/seanblong/readmerunner/actions/workflows/test.yaml)
+[![Coverage](https://img.shields.io/badge/Coverage-73.6%25-brightgreen)](https://github.com/seanblong/readmerunner/actions/workflows/test.yaml)
 [![CI](https://github.com/seanblong/embedmd/actions/workflows/test.yaml/badge.svg)](https://github.com/seanblong/readmerunner/actions/workflows/test.yaml)
 [![Go Report Card](https://goreportcard.com/badge/github.com/seanblong/readmerunner)](https://goreportcard.com/report/github.com/seanblong/readmerunner)
 [![pre-commit.ci status](https://results.pre-commit.ci/badge/github/seanblong/readmerunner/main.svg)](https://results.pre-commit.ci/latest/github/seanblong/readmerunner/main)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Readme Runner
 
-[![Coverage](https://img.shields.io/badge/Coverage-74.2%25-brightgreen)](https://github.com/seanblong/readmerunner/actions/workflows/test.yaml)
+[![Coverage](https://img.shields.io/badge/Coverage-85.4%25-brightgreen)](https://github.com/seanblong/readmerunner/actions/workflows/test.yaml)
 [![CI](https://github.com/seanblong/embedmd/actions/workflows/test.yaml/badge.svg)](https://github.com/seanblong/readmerunner/actions/workflows/test.yaml)
 [![Go Report Card](https://goreportcard.com/badge/github.com/seanblong/readmerunner)](https://goreportcard.com/report/github.com/seanblong/readmerunner)
 [![pre-commit.ci status](https://results.pre-commit.ci/badge/github/seanblong/readmerunner/main.svg)](https://results.pre-commit.ci/latest/github/seanblong/readmerunner/main)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -14,61 +14,74 @@ import (
 
 // DefaultPrompt reads a line from the provided reader after printing msg.
 // This is primarily for testing purposes to mock user input.
-func defaultPrompt(reader *bufio.Reader, msg string) string {
-	fmt.Print(msg)
-	input, _ := reader.ReadString('\n')
+func defaultPrompt(r *bufio.Reader, w io.Writer, msg string) string {
+	fmt.Fprint(w, msg)
+	input, _ := r.ReadString('\n')
 	return strings.TrimSpace(input)
 }
 
-func main() {
+func runMain(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 	var (
 		tocFlag     bool
 		startAnchor string
 		logFile     string
 	)
-	// Define a boolean flag for table-of-contents.
-	flag.BoolVar(&tocFlag, "toc", false, "Print table of contents")
-	flag.StringVar(&startAnchor, "start", "", "Anchor text where to start in run mode")
-	flag.StringVar(&logFile, "log", "readme-runner.log", "Path to log file")
-	flag.Parse()
 
-	if flag.NArg() != 1 {
-		log.Println("Usage: readme-runner [options] <README.md>")
-		os.Exit(1)
+	// Create a new flag set so tests can supply arguments.
+	fs := flag.NewFlagSet("readme-runner", flag.ContinueOnError)
+	// Redirect error output from fs to stderr.
+	fs.SetOutput(stderr)
+
+	fs.BoolVar(&tocFlag, "toc", false, "Print table of contents")
+	fs.StringVar(&startAnchor, "start", "", "Anchor text where to start in run mode")
+	fs.StringVar(&logFile, "log", "readme-runner.log", "Path to log file")
+	if err := fs.Parse(args); err != nil {
+		fmt.Fprintln(stderr, "Error parsing flags:", err)
+		return 1
 	}
-	readmePath := flag.Arg(0)
+
+	if fs.NArg() != 1 {
+		fmt.Fprintln(stderr, "Usage: readme-runner [options] <README.md>")
+		return 1
+	}
+	readmePath := fs.Arg(0)
 	mdContent, err := os.ReadFile(readmePath)
 	if err != nil {
-		log.Println("Error reading file:", err)
-		os.Exit(1)
+		fmt.Fprintln(stderr, "Error reading file:", err)
+		return 1
 	}
 
 	// Open the log file for appending. Create it if it doesn't exist.
 	logF, err := os.OpenFile(logFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 	if err != nil {
-		log.Println("Error opening log file:", err)
-		os.Exit(1)
+		fmt.Fprintln(stderr, "Error opening log file:", err)
+		return 1
 	}
 	defer logF.Close()
 
 	// Use a multiwriter to output to both stdout and the log file.
-	multiOut := io.MultiWriter(os.Stdout, logF)
+	multiOut := io.MultiWriter(stdout, logF)
 
 	if tocFlag {
 		err = readmerunner.PrintTOC(multiOut, mdContent)
 		if err != nil {
-			log.Println("Error printing TOC:", err)
-			os.Exit(1)
+			fmt.Fprintln(stderr, "Error printing TOC:", err)
+			return 1
 		}
 	} else {
-		reader := bufio.NewReader(os.Stdin)
+		reader := bufio.NewReader(stdin)
 		promptFunc := func(msg string) string {
-			return defaultPrompt(reader, msg)
+			return defaultPrompt(reader, stdout, msg)
 		}
 		err = readmerunner.RunMarkdown(mdContent, startAnchor, multiOut, promptFunc)
 		if err != nil {
 			log.Println("Error running markdown:", err)
-			os.Exit(1)
+			return 1
 		}
 	}
+	return 0
+}
+
+func main() {
+	os.Exit(runMain(os.Args[1:], os.Stdin, os.Stdout, os.Stderr))
 }

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -3,12 +3,22 @@ package main
 import (
 	"bufio"
 	"flag"
+	"fmt"
 	"io"
 	"log"
 	"os"
+	"strings"
 
 	"github.com/seanblong/readmerunner" // adjust the import path as needed
 )
+
+// DefaultPrompt reads a line from the provided reader after printing msg.
+// This is primarily for testing purposes to mock user input.
+func defaultPrompt(reader *bufio.Reader, msg string) string {
+	fmt.Print(msg)
+	input, _ := reader.ReadString('\n')
+	return strings.TrimSpace(input)
+}
 
 func main() {
 	var (
@@ -53,7 +63,7 @@ func main() {
 	} else {
 		reader := bufio.NewReader(os.Stdin)
 		promptFunc := func(msg string) string {
-			return readmerunner.DefaultPrompt(reader, msg)
+			return defaultPrompt(reader, msg)
 		}
 		err = readmerunner.RunMarkdown(mdContent, startAnchor, multiOut, promptFunc)
 		if err != nil {

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -9,7 +9,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/seanblong/readmerunner" // adjust the import path as needed
+	"github.com/seanblong/readmerunner"
 )
 
 // DefaultPrompt reads a line from the provided reader after printing msg.

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -1,0 +1,141 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestRunMain_NoArgs(t *testing.T) {
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	// Call runMain with no arguments.
+	exitCode := runMain([]string{}, strings.NewReader(""), stdout, stderr)
+	if exitCode == 0 {
+		t.Errorf("Expected non-zero exit code when no README is provided")
+	}
+	if !strings.Contains(stderr.String(), "Usage:") {
+		t.Errorf("Expected usage message in stderr, got: %s", stderr.String())
+	}
+}
+
+func TestRunMain_TOCMode(t *testing.T) {
+	// Create a temporary README file with some headings.
+	tmpFile, err := os.CreateTemp("", "README_toc_*.md")
+	if err != nil {
+		t.Fatalf("Error creating temp file: %v", err)
+	}
+	defer os.Remove(tmpFile.Name())
+	content := "# Title\n\nSome introduction.\n\n## Section One\nMore details.\n"
+	if _, err := tmpFile.Write([]byte(content)); err != nil {
+		t.Fatalf("Error writing to temp file: %v", err)
+	}
+	tmpFile.Close()
+
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	// Run in TOC mode.
+	exitCode := runMain([]string{"--toc", tmpFile.Name()}, strings.NewReader(""), stdout, stderr)
+	if exitCode != 0 {
+		t.Errorf("Expected exit code 0 in TOC mode, got %d", exitCode)
+	}
+	got := stdout.String()
+	if !strings.Contains(got, "Title") || !strings.Contains(got, "Section One") {
+		t.Errorf("Expected TOC output to contain headings, got: %s", got)
+	}
+}
+
+func TestRunMain_RunModeWithExit(t *testing.T) {
+	// Create a temporary README file with some content.
+	tmpFile, err := os.CreateTemp("", "README_run_*.md")
+	if err != nil {
+		t.Fatalf("Error creating temp file: %v", err)
+	}
+	defer os.Remove(tmpFile.Name())
+	content := "# Intro\n\nWelcome to the README.\n"
+	if _, err := tmpFile.Write([]byte(content)); err != nil {
+		t.Fatalf("Error writing to temp file: %v", err)
+	}
+	tmpFile.Close()
+
+	// Simulate user input by providing "exit\n" so that interactive mode quits.
+	stdin := strings.NewReader("exit\n")
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	exitCode := runMain([]string{tmpFile.Name()}, stdin, stdout, stderr)
+	// In our runMain, a normal exit returns 0.
+	if exitCode != 0 {
+		t.Errorf("Expected exit code 0 in run mode, got %d", exitCode)
+	}
+	got := stdout.String()
+	if !strings.Contains(got, "Intro") {
+		t.Errorf("Expected output to contain 'Intro', got: %s", got)
+	}
+	if strings.Contains(got, "README complete!") {
+		t.Errorf("Expected output should not include final message 'README complete!', got: %s", got)
+	}
+}
+
+func TestRunMain_InvalidLogFile(t *testing.T) {
+	// Create a temporary README file.
+	tmpFile, err := os.CreateTemp("", "README_invalid_log_*.md")
+	if err != nil {
+		t.Fatalf("Error creating temp file: %v", err)
+	}
+	defer os.Remove(tmpFile.Name())
+	content := "# Intro\n\nContent.\n"
+	if _, err := tmpFile.Write([]byte(content)); err != nil {
+		t.Fatalf("Error writing to temp file: %v", err)
+	}
+	tmpFile.Close()
+
+	// Use a log file path that's likely invalid.
+	invalidLogFile := "/invalid/path/readme-runner.log"
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	exitCode := runMain([]string{"--log", invalidLogFile, tmpFile.Name()}, strings.NewReader(""), stdout, stderr)
+	if exitCode == 0 {
+		t.Errorf("Expected non-zero exit code when log file cannot be opened")
+	}
+	if !strings.Contains(stderr.String(), "Error opening log file") {
+		t.Errorf("Expected error message about log file, got: %s", stderr.String())
+	}
+}
+
+func TestRunMain_StartAnchor(t *testing.T) {
+	// Create a temporary README file with some content.
+	tmpFile, err := os.CreateTemp("", "README_start_anchor_*.md")
+	if err != nil {
+		t.Fatalf("Error creating temp file: %v", err)
+	}
+	defer os.Remove(tmpFile.Name())
+	content := "# Intro\n\nWelcome to the README.\n## Section One\nDetails.\n"
+	if _, err := tmpFile.Write([]byte(content)); err != nil {
+		t.Fatalf("Error writing to temp file: %v", err)
+	}
+	tmpFile.Close()
+
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	// Run with a start anchor that matches a section.
+	exitCode := runMain([]string{"--start", "section-one", tmpFile.Name()}, strings.NewReader("exit\n"), stdout, stderr)
+	if exitCode != 0 {
+		t.Errorf("Expected exit code 0 when starting at anchor, got %d", exitCode)
+	}
+	got := stdout.String()
+	if !strings.Contains(got, "Section One") {
+		t.Errorf("Expected output to contain 'Section One', got: %s", got)
+	}
+
+	stdout = new(bytes.Buffer)
+	stderr = new(bytes.Buffer)
+	// Run with a non-existing start anchor.
+	exitCode = runMain([]string{"--start", "non-existing", tmpFile.Name()}, strings.NewReader("exit\n"), stdout, stderr)
+	if exitCode != 0 {
+		t.Errorf("Expected exit code 0 when start anchor does not exist, got %d", exitCode)
+	}
+	if strings.Contains(stdout.String(), "Section One") {
+		t.Errorf("Expected output to not contain 'Section One', got: %s", stdout.String())
+	}
+}

--- a/parser.go
+++ b/parser.go
@@ -212,7 +212,7 @@ func processCodeBlock(w io.Writer, codeBlock *ast.FencedCodeBlock, mdContent []b
 		fmt.Fprintf(w, "\n> Output: %s", out)
 	case "x":
 		// Use a special error value to signal exit.
-		return fmt.Errorf("exit")
+		return nil
 	}
 	return nil
 }

--- a/parser.go
+++ b/parser.go
@@ -1,0 +1,277 @@
+package readmerunner
+
+import (
+	"fmt"
+	"io"
+	"regexp"
+	"strings"
+	"unicode"
+
+	"github.com/yuin/goldmark"
+	"github.com/yuin/goldmark/ast"
+	"github.com/yuin/goldmark/text"
+)
+
+// normalizeAnchor converts a header string into a markdown anchor.
+// It converts the text to lowercase, removes non-alphanumeric characters (except spaces),
+// and replaces spaces with dashes
+func normalizeAnchor(header string) string {
+	lower := strings.ToLower(header)
+	// Remove non-alphanumeric characters (allow spaces).
+	var b strings.Builder
+	for _, r := range lower {
+		if unicode.IsLetter(r) || unicode.IsDigit(r) || r == ' ' {
+			b.WriteRune(r)
+		}
+	}
+	anchor := strings.ReplaceAll(b.String(), " ", "-")
+	// Optionally, collapse multiple dashes (if needed).
+	re := regexp.MustCompile("-+")
+	anchor = re.ReplaceAllString(anchor, "-")
+
+	return anchor
+}
+
+// PrintTOC parses the markdown content and writes a table-of-contents to w.
+func PrintTOC(w io.Writer, mdContent []byte) error {
+	md := goldmark.New()
+	doc := md.Parser().Parse(text.NewReader(mdContent))
+	return ast.Walk(doc, func(n ast.Node, entering bool) (ast.WalkStatus, error) {
+		if n.Kind() == ast.KindHeading && entering {
+			heading := n.(*ast.Heading)
+			indent := strings.Repeat("  ", heading.Level-1)
+			var headerText strings.Builder
+			for c := n.FirstChild(); c != nil; c = c.NextSibling() {
+				if textNode, ok := c.(*ast.Text); ok {
+					headerText.Write(textNode.Segment.Value(mdContent))
+				}
+			}
+			anchor := normalizeAnchor(headerText.String())
+			fmt.Fprintf(w, "%s- %s (%s)\n", indent, headerText.String(), anchor)
+		}
+		return ast.WalkContinue, nil
+	})
+}
+
+// renderHeader prints a markdown header with its level and text.
+func renderHeader(w io.Writer, n *ast.Heading, mdContent []byte) {
+	var headerText strings.Builder
+	for c := n.FirstChild(); c != nil; c = c.NextSibling() {
+		if textNode, ok := c.(*ast.Text); ok {
+			headerText.Write(textNode.Segment.Value(mdContent))
+		}
+	}
+	hashes := strings.Repeat("#", n.Level)
+	fmt.Fprintf(w, "\n%s %s\n", hashes, headerText.String())
+}
+
+func renderBaseContent(w io.Writer, n ast.Node, mdContent []byte) {
+	switch n.Kind() {
+	case ast.KindText:
+		textNode := n.(*ast.Text)
+		fmt.Fprint(w, string(textNode.Segment.Value(mdContent)))
+	default:
+		if n.Lines() != nil && n.Lines().Len() > 0 {
+			for i := 0; i < n.Lines().Len(); i++ {
+				line := n.Lines().At(i)
+				fmt.Fprint(w, string(line.Value(mdContent)))
+			}
+		}
+	}
+}
+
+// renderNodeContent recursively prints the content of a non-header node, e.g.,
+// paragraph, listItem, blockquote, etc.
+func renderNodeContent(w io.Writer, n ast.Node, mdContent []byte) {
+	switch n.Kind() {
+	case ast.KindBlockquote:
+		// renderBlockquote handles block quote nodes by rendering each child and prefixing each line with "> ".
+		bq := n.(*ast.Blockquote)
+		// Iterate over children of the blockquote.
+		fmt.Fprintln(w)
+		for c := bq.FirstChild(); c != nil; c = c.NextSibling() {
+			// Capture the rendered content in a temporary buffer.
+			var buf strings.Builder
+			renderBaseContent(&buf, c, mdContent)
+			// Split the content by newlines.
+			lines := strings.Split(buf.String(), "\n")
+			for _, line := range lines {
+				// Print each non-empty line with a "> " prefix.
+				if strings.TrimSpace(line) != "" {
+					fmt.Fprintf(w, "> %s\n", line)
+				} else {
+					fmt.Fprintln(w, ">")
+				}
+			}
+		}
+	case ast.KindParagraph:
+		fmt.Fprintln(w)
+		paragraph := n.(*ast.Paragraph)
+		if paragraph.HasChildren() {
+			for c := paragraph.FirstChild(); c != nil; c = c.NextSibling() {
+				renderBaseContent(w, c, mdContent)
+			}
+		}
+		fmt.Fprintln(w)
+	default:
+		return
+	}
+}
+
+// renderList handles both ordered and unordered lists by iterating over each list item.
+// If a list item consists solely of a single paragraph, its inline text is rendered on the same line.
+func renderList(w io.Writer, list *ast.List, mdContent []byte, indent string) {
+	index := 1
+	fmt.Fprintln(w)
+	for li := list.FirstChild(); li != nil; li = li.NextSibling() {
+		var bullet string
+		if list.IsOrdered() {
+			bullet = fmt.Sprintf("%d.", index)
+			index++
+		} else {
+			bullet = "-"
+		}
+		// Print bullet with provided indent.
+		fmt.Fprintf(w, "%s%s ", indent, bullet)
+		listItem := li.(*ast.ListItem)
+		if listItem.HasChildren() {
+			for c := listItem.FirstChild(); c != nil; c = c.NextSibling() {
+				// Check for a sublist
+				if c.Kind() == ast.KindList {
+					renderList(w, c.(*ast.List), mdContent, indent+"  ")
+				}
+				renderBaseContent(w, c, mdContent)
+			}
+		}
+
+		fmt.Fprintln(w)
+	}
+}
+
+// RunMarkdown iterates through the markdown content grouped by section.
+// A section is defined as a header and all content until the next header.
+// It writes the section’s content to w and uses promptFunc to get user input.
+// Prompts are printed with newlines before and after.
+// Code blocks are handled interactively (prompting for run/skip/exit).
+// Instead of calling os.Exit, it stops processing when the user types "exit".
+func RunMarkdown(mdContent []byte, startAnchor string, w io.Writer, promptFunc func(string) string) error {
+	md := goldmark.New()
+	doc := md.Parser().Parse(text.NewReader(mdContent))
+
+	// Group nodes into sections (each section is a slice of ast.Node)
+	var sections [][]ast.Node
+	var currentSection []ast.Node
+
+	for n := doc.FirstChild(); n != nil; n = n.NextSibling() {
+		if n.Kind() == ast.KindHeading {
+			if len(currentSection) > 0 {
+				sections = append(sections, currentSection)
+			}
+			currentSection = []ast.Node{n}
+		} else {
+			// Content before any heading becomes its own section.
+			if currentSection == nil {
+				currentSection = []ast.Node{n}
+			} else {
+				currentSection = append(currentSection, n)
+			}
+		}
+	}
+	if len(currentSection) > 0 {
+		sections = append(sections, currentSection)
+	}
+
+	// If a start anchor is provided, skip sections until it is found.
+	started := startAnchor == ""
+	for i, section := range sections {
+		// If the section starts with a heading, check for the start anchor.
+		if len(section) > 0 && section[0].Kind() == ast.KindHeading {
+			heading := section[0].(*ast.Heading)
+			var headerText strings.Builder
+			for c := heading.FirstChild(); c != nil; c = c.NextSibling() {
+				if textNode, ok := c.(*ast.Text); ok {
+					headerText.Write(textNode.Segment.Value(mdContent))
+				}
+			}
+			normalized := normalizeAnchor(headerText.String())
+			if !started && normalized == startAnchor {
+				started = true
+			}
+		}
+		if !started {
+			continue
+		}
+
+		// Process the entire section.
+		for _, n := range section {
+			switch n.Kind() {
+			case ast.KindHeading:
+				heading := n.(*ast.Heading)
+				renderHeader(w, heading, mdContent)
+			case ast.KindFencedCodeBlock:
+				codeBlock := n.(*ast.FencedCodeBlock)
+				language := string(codeBlock.Language(mdContent))
+
+				var codeText strings.Builder
+				for i := 0; i < codeBlock.Lines().Len(); i++ {
+					line := codeBlock.Lines().At(i)
+					codeText.Write(line.Value(mdContent))
+				}
+				// Print the code block with markdown formatting.
+				fmt.Fprintf(w, "\n```%s\n%s```\n", language, codeText.String())
+				// Prompt the user immediately after printing the code block.
+				choice := promptFunc("\n> Run code? (r=run, s=skip, x=exit) [default s]: ")
+				choice = strings.ToLower(strings.TrimSpace(choice))
+				switch choice {
+				case "r":
+					runner := GetRunner(language)
+					if runner == nil {
+						fmt.Fprintf(w, "No runner for language: %s\n", language)
+						continue
+					}
+					out, err := runner.Run(codeText.String())
+					if err != nil {
+						fmt.Fprintf(w, "\n> Error: %s", err.Error())
+					}
+					if out == "" {
+						out = "(no output)\n"
+					}
+					fmt.Fprintf(w, "\n> Output: %s", out)
+				case "x":
+					return nil
+					// default: skip code block execution.
+				}
+			case ast.KindList:
+				list := n.(*ast.List)
+				renderList(w, list, mdContent, "")
+			default:
+				renderNodeContent(w, n, mdContent)
+			}
+		}
+
+		// Default prompt heading, ideally prompt with next section heading.
+		var promptMsg = "\n> Press Enter to continue (or type 'exit'): "
+		if i < len(sections)-1 {
+			nextSection := sections[i+1]
+			if len(nextSection) > 0 && nextSection[0].Kind() == ast.KindHeading {
+				heading := nextSection[0].(*ast.Heading)
+				var nextHeaderText strings.Builder
+				for c := heading.FirstChild(); c != nil; c = c.NextSibling() {
+					if textNode, ok := c.(*ast.Text); ok {
+						nextHeaderText.Write(textNode.Segment.Value(mdContent))
+					}
+				}
+				promptMsg = fmt.Sprintf("\n> Press Enter to continue to [%s] (or type 'exit'): ", nextHeaderText.String())
+			}
+		}
+
+		if strings.ToLower(promptFunc(promptMsg)) == "exit" {
+			return nil
+		}
+		// If this is the last section and user did not exit, print final message.
+		if i == len(sections)-1 {
+			fmt.Fprintln(w, "\n> README complete!")
+		}
+	}
+	return nil
+}

--- a/runner.go
+++ b/runner.go
@@ -2,31 +2,116 @@ package readmerunner
 
 import (
 	"bufio"
-	"fmt"
 	"io"
+	"log"
 	"os/exec"
-	"regexp"
 	"strings"
-	"unicode"
-
-	"github.com/yuin/goldmark"
-	"github.com/yuin/goldmark/ast"
-	"github.com/yuin/goldmark/text"
 )
 
 // CodeRunner defines a standard interface to run code snippets.
 type CodeRunner interface {
 	Run(code string) (string, error)
+	Close() error
+}
+
+// RunnerIO is a wrapper around exec.Cmd to handle stdin/stdout.
+// It allows for running code in a persistent shell.
+type runnerIO struct {
+	cmd     *exec.Cmd
+	stdin   io.WriteCloser
+	stdout  io.ReadCloser
+	scanner *bufio.Scanner
+}
+
+func newRunnerIO(command string) (*runnerIO, error) {
+	cmd := exec.Command(command)
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return nil, err
+	}
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, err
+	}
+	// Merge stderr into stdout so errors are captured.
+	cmd.Stderr = cmd.Stdout
+	if err := cmd.Start(); err != nil {
+		return nil, err
+	}
+	scanner := bufio.NewScanner(stdout)
+	return &runnerIO{
+		cmd:     cmd,
+		stdin:   stdin,
+		stdout:  stdout,
+		scanner: scanner,
+	}, nil
+}
+
+// Run executes the provided code in the persistent shell.
+func (r *runnerIO) Run(code string) (string, error) {
+	marker := "__END_OF_SNIPPET__"
+	// Append marker so we know when the output for this snippet is done.
+	command := code + "\necho " + marker + "\n"
+	if _, err := r.stdin.Write([]byte(command)); err != nil {
+		return "", err
+	}
+	var output strings.Builder
+	for r.scanner.Scan() {
+		line := r.scanner.Text()
+		if line == marker {
+			break
+		}
+		output.WriteString(line + "\n")
+	}
+	if err := r.scanner.Err(); err != nil {
+		return output.String(), err
+	}
+	return output.String(), nil
+}
+
+// Close terminates the shell and cleans up resources.
+func (r *runnerIO) Close() error {
+	if err := r.stdin.Close(); err != nil {
+		return err
+	}
+	if err := r.cmd.Wait(); err != nil {
+		return err
+	}
+	return nil
 }
 
 // BashRunner implements CodeRunner for bash.
-type BashRunner struct{}
+type BashRunner struct {
+	runnerIO
+}
 
-// Run executes the given bash code via the shell.
-func (r *BashRunner) Run(code string) (string, error) {
-	cmd := exec.Command("bash", "-c", code)
-	out, err := cmd.CombinedOutput()
-	return string(out), err
+// bashRunner is a singleton instance of BashRunner.
+var bashRunner *BashRunner
+
+// NewBashRunner spawns a persistent Bash shell.
+func NewBashRunner() (*BashRunner, error) {
+	runner, err := newRunnerIO("bash")
+	if err != nil {
+		return nil, err
+	}
+	return &BashRunner{*runner}, nil
+}
+
+// ShellRunner implements CodeRunner for sh.
+type ShellRunner struct {
+	runnerIO
+}
+
+// shellRunner is a singleton instance of ShellRunner.
+var shellRunner *ShellRunner
+
+// NewShellRunner spawns a persistent shell.
+func NewShellRunner() (*ShellRunner, error) {
+	runner, err := newRunnerIO("sh")
+	if err != nil {
+		return nil, err
+	}
+	return &ShellRunner{*runner}, nil
 }
 
 // GetRunner returns a CodeRunner based on the provided language.
@@ -35,277 +120,26 @@ func (r *BashRunner) Run(code string) (string, error) {
 func GetRunner(lang string) CodeRunner {
 	switch lang {
 	case "bash":
-		return &BashRunner{}
+		if bashRunner == nil {
+			runner, err := NewBashRunner()
+			if err != nil {
+				log.Printf("Error starting bash runner: %v\n", err)
+				return nil
+			}
+			bashRunner = runner
+		}
+		return bashRunner
+	case "sh", "shell":
+		if shellRunner == nil {
+			runner, err := NewShellRunner()
+			if err != nil {
+				log.Printf("Error starting shell runner: %v\n", err)
+				return nil
+			}
+			shellRunner = runner
+		}
+		return shellRunner
 	default:
 		return nil
 	}
-}
-
-// normalizeAnchor converts a header string into a markdown anchor.
-// It converts the text to lowercase, removes non-alphanumeric characters (except spaces),
-// and replaces spaces with dashes
-func normalizeAnchor(header string) string {
-	lower := strings.ToLower(header)
-	// Remove non-alphanumeric characters (allow spaces).
-	var b strings.Builder
-	for _, r := range lower {
-		if unicode.IsLetter(r) || unicode.IsDigit(r) || r == ' ' {
-			b.WriteRune(r)
-		}
-	}
-	anchor := strings.ReplaceAll(b.String(), " ", "-")
-	// Optionally, collapse multiple dashes (if needed).
-	re := regexp.MustCompile("-+")
-	anchor = re.ReplaceAllString(anchor, "-")
-
-	return anchor
-}
-
-// PrintTOC parses the markdown content and writes a table-of-contents to w.
-func PrintTOC(w io.Writer, mdContent []byte) error {
-	md := goldmark.New()
-	doc := md.Parser().Parse(text.NewReader(mdContent))
-	return ast.Walk(doc, func(n ast.Node, entering bool) (ast.WalkStatus, error) {
-		if n.Kind() == ast.KindHeading && entering {
-			heading := n.(*ast.Heading)
-			indent := strings.Repeat("  ", heading.Level-1)
-			var headerText strings.Builder
-			for c := n.FirstChild(); c != nil; c = c.NextSibling() {
-				if textNode, ok := c.(*ast.Text); ok {
-					headerText.Write(textNode.Segment.Value(mdContent))
-				}
-			}
-			anchor := normalizeAnchor(headerText.String())
-			fmt.Fprintf(w, "%s- %s (%s)\n", indent, headerText.String(), anchor)
-		}
-		return ast.WalkContinue, nil
-	})
-}
-
-// DefaultPrompt reads a line from the provided reader after printing msg.
-// This is primarily for testing purposes to mock user input.
-func DefaultPrompt(reader *bufio.Reader, msg string) string {
-	fmt.Print(msg)
-	input, _ := reader.ReadString('\n')
-	return strings.TrimSpace(input)
-}
-
-// renderHeader prints a markdown header with its level and text.
-func renderHeader(w io.Writer, n *ast.Heading, mdContent []byte) {
-	var headerText strings.Builder
-	for c := n.FirstChild(); c != nil; c = c.NextSibling() {
-		if textNode, ok := c.(*ast.Text); ok {
-			headerText.Write(textNode.Segment.Value(mdContent))
-		}
-	}
-	hashes := strings.Repeat("#", n.Level)
-	fmt.Fprintf(w, "\n%s %s\n", hashes, headerText.String())
-}
-
-func renderBaseContent(w io.Writer, n ast.Node, mdContent []byte) {
-	switch n.Kind() {
-	case ast.KindText:
-		textNode := n.(*ast.Text)
-		fmt.Fprint(w, string(textNode.Segment.Value(mdContent)))
-	default:
-		if n.Lines() != nil && n.Lines().Len() > 0 {
-			for i := 0; i < n.Lines().Len(); i++ {
-				line := n.Lines().At(i)
-				fmt.Fprint(w, string(line.Value(mdContent)))
-			}
-		}
-	}
-}
-
-// renderNodeContent recursively prints the content of a generic node, e.g, text
-func renderNodeContent(w io.Writer, n ast.Node, mdContent []byte) {
-	switch n.Kind() {
-	case ast.KindListItem:
-		listItem := n.(*ast.ListItem)
-		if listItem.HasChildren() {
-			for c := listItem.FirstChild(); c != nil; c = c.NextSibling() {
-				renderBaseContent(w, c, mdContent)
-			}
-		}
-	case ast.KindBlockquote:
-		// renderBlockquote handles block quote nodes by rendering each child and prefixing each line with "> ".
-		bq := n.(*ast.Blockquote)
-		// Iterate over children of the blockquote.
-		fmt.Fprintln(w)
-		for c := bq.FirstChild(); c != nil; c = c.NextSibling() {
-			// Capture the rendered content in a temporary buffer.
-			var buf strings.Builder
-			renderBaseContent(&buf, c, mdContent)
-			// Split the content by newlines.
-			lines := strings.Split(buf.String(), "\n")
-			for _, line := range lines {
-				// Print each non-empty line with a "> " prefix.
-				if strings.TrimSpace(line) != "" {
-					fmt.Fprintf(w, "> %s\n", line)
-				} else {
-					fmt.Fprintln(w, ">")
-				}
-			}
-		}
-	case ast.KindParagraph:
-		fmt.Fprintln(w)
-		paragraph := n.(*ast.Paragraph)
-		if paragraph.HasChildren() {
-			for c := paragraph.FirstChild(); c != nil; c = c.NextSibling() {
-				renderBaseContent(w, c, mdContent)
-			}
-		}
-		fmt.Fprintln(w)
-	default:
-		return
-	}
-}
-
-// renderList handles both ordered and unordered lists by iterating over each list item.
-// If a list item consists solely of a single paragraph, its inline text is rendered on the same line.
-func renderList(w io.Writer, list *ast.List, mdContent []byte, indent string) {
-	index := 1
-	fmt.Fprintln(w)
-	for li := list.FirstChild(); li != nil; li = li.NextSibling() {
-		if li.Kind() == ast.KindListItem {
-			var bullet string
-			if list.IsOrdered() {
-				bullet = fmt.Sprintf("%d.", index)
-				index++
-			} else {
-				bullet = "-"
-			}
-			// Print bullet with provided indent.
-			fmt.Fprintf(w, "%s%s ", indent, bullet)
-			renderNodeContent(w, li, mdContent)
-
-			fmt.Fprintln(w)
-		}
-	}
-}
-
-// RunMarkdown iterates through the markdown content grouped by section.
-// A section is defined as a header and all content until the next header.
-// It writes the section’s content to w and uses promptFunc to get user input.
-// Prompts are printed with newlines before and after.
-// Code blocks are handled interactively (prompting for run/skip/exit).
-// Instead of calling os.Exit, it stops processing when the user types "exit".
-func RunMarkdown(mdContent []byte, startAnchor string, w io.Writer, promptFunc func(string) string) error {
-	md := goldmark.New()
-	doc := md.Parser().Parse(text.NewReader(mdContent))
-
-	// Group nodes into sections (each section is a slice of ast.Node)
-	var sections [][]ast.Node
-	var currentSection []ast.Node
-
-	for n := doc.FirstChild(); n != nil; n = n.NextSibling() {
-		if n.Kind() == ast.KindHeading {
-			if len(currentSection) > 0 {
-				sections = append(sections, currentSection)
-			}
-			currentSection = []ast.Node{n}
-		} else {
-			// Content before any heading becomes its own section.
-			if currentSection == nil {
-				currentSection = []ast.Node{n}
-			} else {
-				currentSection = append(currentSection, n)
-			}
-		}
-	}
-	if len(currentSection) > 0 {
-		sections = append(sections, currentSection)
-	}
-
-	// If a start anchor is provided, skip sections until it is found.
-	started := startAnchor == ""
-	for i, section := range sections {
-		// If the section starts with a heading, check for the start anchor.
-		if len(section) > 0 && section[0].Kind() == ast.KindHeading {
-			heading := section[0].(*ast.Heading)
-			var headerText strings.Builder
-			for c := heading.FirstChild(); c != nil; c = c.NextSibling() {
-				if textNode, ok := c.(*ast.Text); ok {
-					headerText.Write(textNode.Segment.Value(mdContent))
-				}
-			}
-			normalized := normalizeAnchor(headerText.String())
-			if !started && normalized == startAnchor {
-				started = true
-			}
-		}
-		if !started {
-			continue
-		}
-
-		// Process the entire section.
-		for _, n := range section {
-			switch n.Kind() {
-			case ast.KindHeading:
-				heading := n.(*ast.Heading)
-				renderHeader(w, heading, mdContent)
-			case ast.KindFencedCodeBlock:
-				codeBlock := n.(*ast.FencedCodeBlock)
-				language := string(codeBlock.Language(mdContent))
-
-				var codeText strings.Builder
-				for i := 0; i < codeBlock.Lines().Len(); i++ {
-					line := codeBlock.Lines().At(i)
-					codeText.Write(line.Value(mdContent))
-				}
-				// Print the code block with markdown formatting.
-				fmt.Fprintf(w, "\n```%s\n%s```\n", language, codeText.String())
-				// Prompt the user immediately after printing the code block.
-				choice := promptFunc("\n> Run code? (r=run, s=skip, x=exit) [default s]: ")
-				choice = strings.ToLower(strings.TrimSpace(choice))
-				switch choice {
-				case "r":
-					runner := GetRunner(language)
-					if runner == nil {
-						fmt.Fprintf(w, "No runner for language: %s\n", language)
-						continue
-					}
-					out, err := runner.Run(codeText.String())
-					if err != nil {
-						fmt.Fprintf(w, "\n> Error: %s", err.Error())
-					}
-					fmt.Fprintf(w, "\n> Output: %s", out)
-				case "x":
-					return nil
-					// default: skip code block execution.
-				}
-			case ast.KindList:
-				// Render lists using the helper function.
-				list := n.(*ast.List)
-				renderList(w, list, mdContent, "")
-			default:
-				renderNodeContent(w, n, mdContent)
-			}
-		}
-
-		// Default prompt heading, ideally prompt with next section heading.
-		var promptMsg = "\n> Press Enter to continue (or type 'exit'): "
-		if i < len(sections)-1 {
-			nextSection := sections[i+1]
-			if len(nextSection) > 0 && nextSection[0].Kind() == ast.KindHeading {
-				heading := nextSection[0].(*ast.Heading)
-				var nextHeaderText strings.Builder
-				for c := heading.FirstChild(); c != nil; c = c.NextSibling() {
-					if textNode, ok := c.(*ast.Text); ok {
-						nextHeaderText.Write(textNode.Segment.Value(mdContent))
-					}
-				}
-				promptMsg = fmt.Sprintf("\n> Press Enter to continue to [%s] (or type 'exit'): ", nextHeaderText.String())
-			}
-		}
-
-		if strings.ToLower(promptFunc(promptMsg)) == "exit" {
-			return nil
-		}
-		// If this is the last section and user did not exit, print final message.
-		if i == len(sections)-1 {
-			fmt.Fprintln(w, "\n> README complete!")
-		}
-	}
-	return nil
 }

--- a/runner_test.go
+++ b/runner_test.go
@@ -192,6 +192,8 @@ Oh no, a match!
 func TestComplexMarkdown(t *testing.T) {
 	mdContent := []byte(`# Title
 - item1
+   - subitem1
+   - subitem2
 - item2
 
 More text.
@@ -210,7 +212,7 @@ No newline.
 		t.Errorf("RunMarkdown returned error: %v", err)
 	}
 	got := buf.String()
-	want := "\n# Title\n\n- item1\n- item2\n\nMore text.No newline.\n\n## Subheader\n\n> Quote section\n> More content\n"
+	want := "\n# Title\n\n- item1\n  - subitem1\n  - subitem2\n\n- item2\n\nMore text.No newline.\n\n## Subheader\n\n> Quote section\n> More content\n"
 	if got != want {
 		t.Errorf("RunMarkdown output mismatch.\nGot:\n%s\nWant:\n%s", got, want)
 	}

--- a/runner_test.go
+++ b/runner_test.go
@@ -25,6 +25,8 @@ func TestGetRunner(t *testing.T) {
 		supported bool
 	}{
 		{"bash", true},
+		{"sh", true},
+		{"shell", true},
 		{"python", false},
 		{"go", false},
 		{"", false},
@@ -40,7 +42,7 @@ func TestGetRunner(t *testing.T) {
 }
 
 func TestBashRunnerRun(t *testing.T) {
-	br := &BashRunner{}
+	br, _ := NewBashRunner()
 	output, err := br.Run("echo hello")
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)


### PR DESCRIPTION
# readmerunner PR

## Description

* Split parsing logic from code runner logic
* Fixed bug where sublists weren't rendering
* Move defaultPrompt to the main which is the only place it's used
* Reduce cyclomatic complexity
* Add test cases for main

## Type of Change

- [ ] Feature (feat)
- [X] Fix (fix)
- [ ] Documentation (docs)
- [X] Refactoring (refactor)
- [ ] Reverting change (revert)
- [ ] Performance improvement (perf)
- [ ] Chore (chore)
- [X] Test (test)
- [ ] Continuous Integration (ci)

## Testing

Tests have been updated to reflect changes.

## Additional Information

N/A

## Checklist

- [X] My code adheres to the coding and [style guidelines][1] of the project.
- [X] My PR title follows the [conventional commit][2] format.
- [X] I have made corresponding changes to the documentation, e.g., comments, READMEs
- [X] My changes generate no new errors/warnings

<!-- links -->
[1]: ../CONTRIBUTING.md
[2]: ../CONTRIBUTING.md#pr-title
