### PR TITLE
fix: bind verification to existing shell

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ go install github.com/seanblong/readmerunner/readmerunner@latest
 
 Download the latest binary from the [releases page][2].
 
-## Building
+### Building
 
 ```bash
 go build -o readme-runner .
@@ -64,6 +64,15 @@ Usage: readme-runner [options] <README.md>
   -toc
         Print table of contents
 ```
+
+### Supported Languages
+
+Readme Runner supports the following languages for code snippets:
+
+- `bash`
+- `sh`/`shell`
+
+It will not run empty fences or `console`.
 
 ### Examples
 
@@ -218,9 +227,11 @@ using the `-start` flag ahead of the section.
 
 Readme Runner provides a reserved way to execute verification steps.  Simply add
 a code fence with the language `verify` and the code snippet will be executed in
-a subshell.  The exit code of the subshell will determine if the verification
-passed or failed.  This can be used to wait for processes to complete, check
-environment variables, or any other verification step.
+the same `bash` or `shell` subshells used in the rest of the README.  This will
+give it access to the same environment variables and prompt responses.  The difference
+is that Readme Runner will print the response as a Success or Failure message.
+This can be used to wait for processes to complete, check environment variables
+are set and are correct, or any other verification step.
 
 For example, the following code snippet will always pass,
 
@@ -240,6 +251,11 @@ ls | grep -q README.md
 
 If it does we expect the exit code to be 0, if not we expect the return/exit code
 to be 1.  The verify step will prompt to rerun the verification step if it fails.
+This can be helpful for long running processes that need to be verified before continuing.
+
+> [!CAUTION]
+> The `verify` runner will attempt to attach to an existing subshell.  Try to only
+> use one f
 
 
 <!-- links -->

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <img align="right" hspace="30" width="auto" height="200" src="./assets/readmerunner.png">
 
-[![Coverage](https://img.shields.io/badge/Coverage-81.5%25-brightgreen)](https://github.com/seanblong/readmerunner/actions/workflows/test.yaml)
+[![Coverage](https://img.shields.io/badge/Coverage-80.6%25-brightgreen)](https://github.com/seanblong/readmerunner/actions/workflows/test.yaml)
 [![CI](https://github.com/seanblong/embedmd/actions/workflows/test.yaml/badge.svg)](https://github.com/seanblong/readmerunner/actions/workflows/test.yaml)
 [![Go Report Card](https://goreportcard.com/badge/github.com/seanblong/readmerunner)](https://goreportcard.com/report/github.com/seanblong/readmerunner)
 [![pre-commit.ci status](https://results.pre-commit.ci/badge/github/seanblong/readmerunner/main.svg)](https://results.pre-commit.ci/latest/github/seanblong/readmerunner/main)

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,3 @@
 module github.com/seanblong/readmerunner
 
 go 1.22.1
-
-require github.com/yuin/goldmark v1.7.8

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,0 @@
-github.com/yuin/goldmark v1.7.8 h1:iERMLn0/QJeHFhxSt3p6PeN9mGnvIKSpG9YYorDMnic=
-github.com/yuin/goldmark v1.7.8/go.mod h1:uzxRWxtg69N339t3louHJ7+O03ezfj6PlliRlaOzY1E=

--- a/readmerunner/parser.go
+++ b/readmerunner/parser.go
@@ -193,7 +193,7 @@ func processCodeBlock(w io.Writer, promptFunc func(string) string, code []string
 
 	if choice == "" {
 		if runner == nil {
-			strings.ToLower(strings.TrimSpace(promptFunc("\n> No runner for this language or missing code fence language. Press Enter to continue: ")))
+			promptFunc("\n> No runner for this language or missing code fence language. Press Enter to continue: ")
 			return nil, false
 		} else {
 			choice = strings.ToLower(strings.TrimSpace(promptFunc("\n> Run code? (r=run, s=skip, x=exit) [default s]: ")))

--- a/readmerunner/parser.go
+++ b/readmerunner/parser.go
@@ -189,16 +189,18 @@ func processCodeBlock(w io.Writer, promptFunc func(string) string, code []string
 		language = parts[1]
 	}
 	codeText := strings.Join(code[1:len(code)-1], "\n")
+	runner := GetRunner(language)
+
 	if choice == "" {
-		choice = strings.ToLower(strings.TrimSpace(promptFunc("\n> Run code? (r=run, s=skip, x=exit) [default s]: ")))
+		if runner == nil {
+			strings.ToLower(strings.TrimSpace(promptFunc("\n> No runner for this language or missing code fence language. Press Enter to continue: ")))
+			return nil, false
+		} else {
+			choice = strings.ToLower(strings.TrimSpace(promptFunc("\n> Run code? (r=run, s=skip, x=exit) [default s]: ")))
+		}
 	}
 	switch choice {
 	case "r":
-		runner := GetRunner(language)
-		if runner == nil {
-			fmt.Fprintf(w, "No runner for language: %s\n", language)
-			return nil, false
-		}
 		out, err := runner.Run(codeText)
 		if err != nil {
 			fmt.Fprintf(w, "\n> Error: %s", err.Error())

--- a/readmerunner/runner.go
+++ b/readmerunner/runner.go
@@ -122,16 +122,21 @@ type VerifyRunner struct {
 	runnerIO
 }
 
-// shellRunner is a singleton instance of ShellRunner.
+// verifyRunner is a singleton instance of VerifyRunner.
 var verifyRunner *VerifyRunner
 
-// NewShellRunner spawns a persistent shell.
+// NewVerifyRunner attaches to an existing shell to access variables for potential
+// verification.  If no shell exists then it creates a new one.
 func NewVerifyRunner() (*VerifyRunner, error) {
-	runner, err := newRunnerIO("bash")
-	if err != nil {
-		return nil, err
+	if bashRunner != nil {
+		return &VerifyRunner{runnerIO: bashRunner.runnerIO}, nil
+	} else if shellRunner != nil {
+		return &VerifyRunner{runnerIO: shellRunner.runnerIO}, nil
+	} else {
+		b, _ := NewBashRunner()
+		bashRunner = b
+		return &VerifyRunner{runnerIO: b.runnerIO}, nil
 	}
-	return &VerifyRunner{*runner}, nil
 }
 
 // Run executes the provided code in the persistent shell, returning "Success" or

--- a/readmerunner/runner_test.go
+++ b/readmerunner/runner_test.go
@@ -148,8 +148,8 @@ func TestProcessCodeBlock(t *testing.T) {
 		expectedOutput  string
 	}{
 		{"Run Code Block", []string{"```bash", "echo hello", "```"}, []string{"r"}, "Output: hello"},
-		{"Unknown Language", []string{"```unknown", "echo hello", "```"}, []string{"r"}, "No runner for language: unknown"},
-		{"Missing Language", []string{"```", "echo hello", "```"}, []string{"r"}, "No runner for language: "},
+		{"Unknown Language", []string{"```unknown", "echo hello", "```"}, []string{"r"}, ""},
+		{"Missing Language", []string{"```", "echo hello", "```"}, []string{"r"}, ""},
 		{"Skip Code Block", []string{"```bash", "echo hello", "```"}, []string{"s"}, ""},
 		{"Exit Code Block", []string{"```bash", "echo hello", "```"}, []string{"x"}, ""},
 		{"Rerun Code Block", []string{"```bash", "echo hello", "```"}, []string{"r", "r"}, "\n> Output: hello\n\n> Output: hello\n"},


### PR DESCRIPTION
## Description

The `verification` function works great when processing prompts or running atomically, e.g., checking if file exists, but it fails when variables were set in a separate bash shell.  On a best effort basis it will attempt to bind to the existing shell, currently either a `bash` or `shell`, so that it can reuse existing environment variables.

## Type of Change

- [ ] Feature (feat)
- [X] Fix (fix)
- [X] Documentation (docs)
- [ ] Refactoring (refactor)
- [ ] Reverting change (revert)
- [ ] Performance improvement (perf)
- [ ] Chore (chore)
- [ ] Test (test)
- [ ] Continuous Integration (ci)

## Testing

Updated existing tests to reflect new behavior.

## Additional Information

N/A

## Checklist

- [X] My code adheres to the coding and [style guidelines][1] of the project.
- [X] My PR title follows the [conventional commit][2] format.
- [X] I have made corresponding changes to the documentation, e.g., comments, READMEs
- [X] My changes generate no new errors/warnings

<!-- links -->
[1]: ../CONTRIBUTING.md
[2]: ../CONTRIBUTING.md#pr-title
